### PR TITLE
Ldap new 'ldapDnBase' field and ldapQuery improvement

### DIFF
--- a/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
+++ b/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.naming.NamingEnumeration;
 import javax.naming.directory.Attribute;
@@ -88,19 +89,11 @@ public class LDAPClient {
 
         for (String variableName : taskVariablesList) {
             Serializable value = credentials.getOrDefault(variableName, actualTaskVariables.get(variableName));
-            setLdapClientFields(variableName, value);
+            allLDAPClientParameters.put(variableName,
+                                        (String) Optional.ofNullable(value)
+                                                         .orElseThrow(() -> new IllegalArgumentException("The missed argument for LDAPClient, variable name: " +
+                                                                                                         variableName)));
         }
-    }
-
-    private void setLdapClientFields(String variableName, Serializable value) {
-        if (value == null) {
-            throw new IllegalArgumentException("The missed argument for LDAPClient, variable name: " + variableName);
-        }
-        allLDAPClientParameters.put(variableName, (String) value);
-    }
-
-    private String getAsString(Map<String, Serializable> map, String argFrom) {
-        return (String) map.get(argFrom);
     }
 
     private String[] splitAttributes(String attrList) {

--- a/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
+++ b/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
@@ -99,10 +99,10 @@ public class LDAPClient {
 
         for (String variableName : taskVariablesList) {
             Map<String, Serializable> mapWithVariables;
-            if (actualTaskVariables.containsKey(variableName)) {
-                mapWithVariables = actualTaskVariables;
-            } else {
+            if (credentials.containsKey(variableName)) {
                 mapWithVariables = credentials;
+            } else {
+                mapWithVariables = actualTaskVariables;
             }
             setLdapClientFields(mapWithVariables, variableName);
         }

--- a/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
+++ b/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
@@ -156,7 +156,7 @@ public class LDAPClient {
                 SearchResult searchResult = (SearchResult) results.next();
                 Attributes attributes = searchResult.getAttributes();
 
-                if (attributes != null) {
+                if (attributes != null && attributes.size() > 0) {
                     NamingEnumeration ae = attributes.getAll();
                     Map<String, String> attributesMap = new HashMap<>();
                     while (ae.hasMore()) {

--- a/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
+++ b/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
@@ -98,21 +98,16 @@ public class LDAPClient {
                                                                    ARG_SELECTED_ATTRIBUTES);
 
         for (String variableName : taskVariablesList) {
-            Map<String, Serializable> mapWithVariables;
-            if (credentials.containsKey(variableName)) {
-                mapWithVariables = credentials;
-            } else {
-                mapWithVariables = actualTaskVariables;
-            }
-            setLdapClientFields(mapWithVariables, variableName);
+            Serializable value = credentials.getOrDefault(variableName, actualTaskVariables.get(variableName));
+            setLdapClientFields(variableName, value);
         }
     }
 
-    private void setLdapClientFields(Map<String, Serializable> taskVariablesMap, String variableName) {
-        if (!taskVariablesMap.containsKey(variableName)) {
+    private void setLdapClientFields(String variableName, Serializable value) {
+        if (value == null) {
             throw new IllegalArgumentException("The missed argument for LDAPClient, variable name: " + variableName);
         }
-        allLDAPClientParameters.put(variableName, (String) taskVariablesMap.get(variableName));
+        allLDAPClientParameters.put(variableName, (String) value);
     }
 
     private String getAsString(Map<String, Serializable> map, String argFrom) {

--- a/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
+++ b/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
@@ -77,8 +77,8 @@ public class LDAPClient {
 
     protected DirContext ldapConnection;
 
-    public LDAPClient(String ldapUrl, String ldapDnBase, String ldapUsername, String ldapPassword, String ldapSearchBase,
-            String ldapSearchFilter, String ldapSelectedAttributes) {
+    public LDAPClient(String ldapUrl, String ldapDnBase, String ldapUsername, String ldapPassword,
+            String ldapSearchBase, String ldapSearchFilter, String ldapSelectedAttributes) {
         allLDAPClientParameters.put(ARG_URL, ldapUrl);
         allLDAPClientParameters.put(ARG_DN_BASE, ldapDnBase);
         allLDAPClientParameters.put(ARG_USERNAME, ldapUsername);
@@ -147,7 +147,7 @@ public class LDAPClient {
                 controls.setReturningAttributes(attributesToReturn);
             }
             results = ldapConnection.search(getFullLdapSearchBase(allLDAPClientParameters.get(ARG_DN_BASE),
-                    allLDAPClientParameters.get(ARG_SEARCH_BASE)),
+                                                                  allLDAPClientParameters.get(ARG_SEARCH_BASE)),
                                             allLDAPClientParameters.get(ARG_SEARCH_FILTER),
                                             controls);
 
@@ -198,9 +198,7 @@ public class LDAPClient {
             return ldapSearchBase;
         }
         StringBuilder fullSearchBase = new StringBuilder();
-        fullSearchBase.append(ldapSearchBase)
-                .append(',')
-                .append(ldapDnBase);
+        fullSearchBase.append(ldapSearchBase).append(',').append(ldapDnBase);
         return fullSearchBase.toString();
     }
 }

--- a/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
+++ b/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
@@ -77,17 +77,6 @@ public class LDAPClient {
 
     protected DirContext ldapConnection;
 
-    public LDAPClient(String ldapUrl, String ldapDnBase, String ldapUsername, String ldapPassword,
-            String ldapSearchBase, String ldapSearchFilter, String ldapSelectedAttributes) {
-        allLDAPClientParameters.put(ARG_URL, ldapUrl);
-        allLDAPClientParameters.put(ARG_DN_BASE, ldapDnBase);
-        allLDAPClientParameters.put(ARG_USERNAME, ldapUsername);
-        allLDAPClientParameters.put(ARG_PASSWORD, ldapPassword);
-        allLDAPClientParameters.put(ARG_SEARCH_BASE, ldapSearchBase);
-        allLDAPClientParameters.put(ARG_SEARCH_FILTER, ldapSearchFilter);
-        allLDAPClientParameters.put(ARG_SELECTED_ATTRIBUTES, ldapSelectedAttributes);
-    }
-
     public LDAPClient(Map<String, Serializable> actualTaskVariables, Map<String, Serializable> credentials) {
         ImmutableList<String> taskVariablesList = ImmutableList.of(ARG_URL,
                                                                    ARG_DN_BASE,

--- a/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
+++ b/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPClient.java
@@ -195,7 +195,7 @@ public class LDAPClient {
 
     private static String getFullLdapSearchBase(String ldapDnBase, String ldapSearchBase) {
         if (ldapSearchBase.isEmpty()) {
-            return ldapSearchBase;
+            return ldapDnBase;
         }
         StringBuilder fullSearchBase = new StringBuilder();
         fullSearchBase.append(ldapSearchBase).append(',').append(ldapDnBase);

--- a/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPConnectionUtility.java
+++ b/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPConnectionUtility.java
@@ -43,7 +43,8 @@ public class LDAPConnectionUtility {
 
     private final static String SECURITY_AUTHENTICATION_METHOD = "simple";
 
-    public static DirContext connect(String ldapUrl, String ldapDnBase, String ldapUsername, String ldapPassword) throws NamingException {
+    public static DirContext connect(String ldapUrl, String ldapDnBase, String ldapUsername, String ldapPassword)
+            throws NamingException {
         Hashtable<String, String> env = new Hashtable<>();
         env.put(Context.INITIAL_CONTEXT_FACTORY, LDAP_FACTORY);
         env.put(Context.PROVIDER_URL, ldapUrl);
@@ -52,12 +53,10 @@ public class LDAPConnectionUtility {
         env.put(Context.SECURITY_PRINCIPAL, getFullLdapUserName(ldapDnBase, ldapUsername));
         return new InitialDirContext(env);
     }
-    
+
     private static String getFullLdapUserName(String ldapDnBase, String ldapUsername) {
         StringBuilder fullUserName = new StringBuilder();
-        fullUserName.append(ldapUsername)
-                .append(',')
-                .append(ldapDnBase);
+        fullUserName.append(ldapUsername).append(',').append(ldapDnBase);
         return fullUserName.toString();
     }
 }

--- a/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPConnectionUtility.java
+++ b/src/main/java/org/ow2/proactive/addons/ldap_query/LDAPConnectionUtility.java
@@ -43,13 +43,21 @@ public class LDAPConnectionUtility {
 
     private final static String SECURITY_AUTHENTICATION_METHOD = "simple";
 
-    public static DirContext connect(String ldapUrl, String ldapUsername, String ldapPassword) throws NamingException {
+    public static DirContext connect(String ldapUrl, String ldapDnBase, String ldapUsername, String ldapPassword) throws NamingException {
         Hashtable<String, String> env = new Hashtable<>();
         env.put(Context.INITIAL_CONTEXT_FACTORY, LDAP_FACTORY);
         env.put(Context.PROVIDER_URL, ldapUrl);
         env.put(Context.SECURITY_AUTHENTICATION, SECURITY_AUTHENTICATION_METHOD);
         env.put(Context.SECURITY_CREDENTIALS, ldapPassword);
-        env.put(Context.SECURITY_PRINCIPAL, ldapUsername);
+        env.put(Context.SECURITY_PRINCIPAL, getFullLdapUserName(ldapDnBase, ldapUsername));
         return new InitialDirContext(env);
+    }
+    
+    private static String getFullLdapUserName(String ldapDnBase, String ldapUsername) {
+        StringBuilder fullUserName = new StringBuilder();
+        fullUserName.append(ldapUsername)
+                .append(',')
+                .append(ldapDnBase);
+        return fullUserName.toString();
     }
 }

--- a/src/test/java/org/ow2/proactive/addons/ldap_query/LDAPClientTest.java
+++ b/src/test/java/org/ow2/proactive/addons/ldap_query/LDAPClientTest.java
@@ -69,13 +69,15 @@ public class LDAPClientTest {
 
     private String ldapUrl = "ldap://localhost:389";
 
-    private String ldapSearchBase = "dc=yourOrganization,dc=com";
+    private String ldapDnBase = "dc=yourOrganization,dc=com";
+
+    private String ldapSearchBase = "dc=sophia";
 
     private String ldapSearchFilter = "(objectclass=*)";
 
     private String ldapSelectedAttributes = "attributeName1,attributeName2";
 
-    private String ldapUsername = "cn=admin,dc=com";
+    private String ldapUsername = "cn=admin,ou=users";
 
     private String ldapPassword = "adminPassword";
 
@@ -88,6 +90,7 @@ public class LDAPClientTest {
     public void testLDAPClientConstructFromMaps() {
         Map mapVariables = new HashMap();
         mapVariables.put("ldapUrl", ldapUrl);
+        mapVariables.put("ldapDnBase", ldapDnBase);
         mapVariables.put("ldapSearchBase", ldapSearchBase);
         mapVariables.put("ldapSearchFilter", ldapSearchFilter);
         mapVariables.put("ldapSelectedAttributes", ldapSelectedAttributes);

--- a/src/test/java/org/ow2/proactive/addons/ldap_query/LDAPClientTest.java
+++ b/src/test/java/org/ow2/proactive/addons/ldap_query/LDAPClientTest.java
@@ -119,11 +119,15 @@ public class LDAPClientTest {
     public void testOkResultSearchQueryLDAP() throws NamingException, IOException {
         PowerMockito.mockStatic(LDAPConnectionUtility.class);
         try {
-            when(LDAPConnectionUtility.connect(ldapUrl, ldapUsername, ldapPassword)).thenReturn(ldapConnection);
+            when(LDAPConnectionUtility.connect(ldapUrl,
+                                               ldapDnBase,
+                                               ldapUsername,
+                                               ldapPassword)).thenReturn(ldapConnection);
         } catch (NamingException e) {
             e.printStackTrace();
         }
         ldapClient = new LDAPClient(ldapUrl,
+                                    ldapDnBase,
                                     ldapUsername,
                                     ldapPassword,
                                     ldapSearchBase,
@@ -143,6 +147,7 @@ public class LDAPClientTest {
     @Test
     public void testErrorResultSearchQueryLDAP() throws NamingException, IOException {
         ldapClient = new LDAPClient(ldapUrl,
+                                    ldapDnBase,
                                     ldapUsername,
                                     ldapPassword,
                                     ldapSearchBase,

--- a/src/test/java/org/ow2/proactive/addons/ldap_query/LDAPClientTest.java
+++ b/src/test/java/org/ow2/proactive/addons/ldap_query/LDAPClientTest.java
@@ -88,16 +88,7 @@ public class LDAPClientTest {
 
     @Test
     public void testLDAPClientConstructFromMaps() {
-        Map mapVariables = new HashMap();
-        mapVariables.put("ldapUrl", ldapUrl);
-        mapVariables.put("ldapDnBase", ldapDnBase);
-        mapVariables.put("ldapSearchBase", ldapSearchBase);
-        mapVariables.put("ldapSearchFilter", ldapSearchFilter);
-        mapVariables.put("ldapSelectedAttributes", ldapSelectedAttributes);
-        Map mapCredentials = new HashMap();
-        mapCredentials.put("ldapUsername", ldapUsername);
-        mapCredentials.put("ldapPassword", ldapPassword);
-        ldapClient = new LDAPClient(mapVariables, mapCredentials);
+        ldapClient = getLdapClient();
 
         assertThat(ldapClient.allLDAPClientParameters.get(LDAPClient.ARG_URL), is(ldapUrl));
         assertThat(ldapClient.allLDAPClientParameters.get(LDAPClient.ARG_SEARCH_BASE), is(ldapSearchBase));
@@ -126,13 +117,7 @@ public class LDAPClientTest {
         } catch (NamingException e) {
             e.printStackTrace();
         }
-        ldapClient = new LDAPClient(ldapUrl,
-                                    ldapDnBase,
-                                    ldapUsername,
-                                    ldapPassword,
-                                    ldapSearchBase,
-                                    ldapSearchFilter,
-                                    ldapSelectedAttributes);
+        ldapClient = getLdapClient();
 
         NamingEnumeration results = mock(NamingEnumeration.class);
         when(ldapConnection.search(anyString(), anyString(), any(SearchControls.class))).thenReturn(results);
@@ -146,16 +131,23 @@ public class LDAPClientTest {
 
     @Test
     public void testErrorResultSearchQueryLDAP() throws NamingException, IOException {
-        ldapClient = new LDAPClient(ldapUrl,
-                                    ldapDnBase,
-                                    ldapUsername,
-                                    ldapPassword,
-                                    ldapSearchBase,
-                                    ldapSearchFilter,
-                                    ldapSelectedAttributes);
+        ldapClient = getLdapClient();
         String jsonResponse = ldapClient.searchQueryLDAP();
         Response response = mapper.readValue(jsonResponse, ErrorResponse.class);
         assertThat(response.getStatus(), is("Error"));
     }
 
+    private LDAPClient getLdapClient() {
+        Map mapVariables = new HashMap();
+        mapVariables.put("ldapUrl", ldapUrl);
+        mapVariables.put("ldapDnBase", ldapDnBase);
+        mapVariables.put("ldapSearchBase", ldapSearchBase);
+        mapVariables.put("ldapSearchFilter", ldapSearchFilter);
+        mapVariables.put("ldapSelectedAttributes", ldapSelectedAttributes);
+        Map mapCredentials = new HashMap();
+        mapCredentials.put("ldapUsername", ldapUsername);
+        mapCredentials.put("ldapPassword", ldapPassword);
+        ldapClient = new LDAPClient(mapVariables, mapCredentials);
+        return ldapClient;
+    }
 }


### PR DESCRIPTION
 - A new 'ldapDnBase' field is now the only attribute that contains the distinguished name of the LDAP catalog. It is then concatenated to the `ldapUsername` and `ldapSearchBase` fields.
 - Some code improvements have been made into `searchQueryLDAP`, basically we now only ask the server for the specific attributes needed by the user.
 - We prefer credentials variables over public ones in order to let the user decide itself of its variables privacy